### PR TITLE
Add automatic everyday reset for Habit complete column with cron job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ gem 'rubocop'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'rubocop'
 end
 
 group :development do

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -56,7 +56,7 @@ class HabitsController < ApplicationController
     @habit = Habit.find(params[:id])
     @goal = @habit.goal
 
-    if @habit.keep?
+    if @habit.completed_today?
       flash[:noticed] = "You have already completed this habit today!"
       redirect_to goal_path(@goal)
     else
@@ -72,6 +72,6 @@ class HabitsController < ApplicationController
   end
 
   def habit_params
-    params.require(:habit).permit(:name, :description, :days_completed, :keep)
+    params.require(:habit).permit(:name, :description, :days_completed, :completed)
   end
 end

--- a/app/helpers/habits_helper.rb
+++ b/app/helpers/habits_helper.rb
@@ -1,6 +1,9 @@
 module HabitsHelper
   def habits_completed(goal)
-    completed = goal.habits.where(keep: true).count
+    completed = CompletionDate
+                  .where('habit_id IN (?) AND created_at >= ?',
+                         goal.habits.select(:id), Date.today.beginning_of_day).count
+
     all = goal.habits.count
     habits = completed == 0 ? 0 : completed
     "#{habits}/#{all}"

--- a/app/models/completion_date.rb
+++ b/app/models/completion_date.rb
@@ -1,3 +1,5 @@
 class CompletionDate < ApplicationRecord
   belongs_to :habit
+
+  scope :created_today, -> { where('created_at >= ?', Date.today.beginning_of_day) }
 end

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -62,9 +62,9 @@
             <td><%= link_to habit.name, edit_goal_habit_path(@goal, habit), style: "text-decoration: none" %></td>
             <td><%= habit.description.truncate(15) %></td>
             <td>
-              <%= link_to "#{habit.keep? ? 'completed' : 'in process'}",
+              <%= link_to "#{habit.completed_today? ? 'completed' : 'in process'}",
                           complete_habit_path(habit),
-                          class: "#{habit.keep? ? 'btn btn-success btn-sm' : 'btn btn-warning btn-sm'}" %>
+                          class: "#{habit.completed_today? ? 'btn btn-success btn-sm' : 'btn btn-warning btn-sm'}" %>
             </td>
           <% end %>
         </tr>

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -14,7 +14,7 @@
       </thead>
 
       <% if @habits.present? %>
-        <% @habits.completed(@goal, current_user).each_with_index do |habit, index| %>
+        <% @habits.completed(@goal).each_with_index do |habit, index| %>
           <tr>
             <th scope="row"><%= index + 1 %></th>
             <td><%= link_to habit.name.truncate(15), goal_habit_path(@goal, habit) %></td>
@@ -40,7 +40,7 @@
       </thead>
 
       <% if @habits.present? %>
-        <% @habits.uncompleted(@goal, current_user).each_with_index do |habit, index| %>
+        <% @habits.uncompleted(@goal).each_with_index do |habit, index| %>
           <tr>
             <th scope="row"><%= index + 1 %></th>
             <td><%= link_to habit.name.truncate(15), goal_habit_path(@goal, habit) %></td>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -2,7 +2,7 @@
   <h1>Habits#show</h1>
   <p><%= @habit.name %></p>
   <p><%= @habit.description %></p>
-  <p><%= @habit.keep? ? "Keep today" : "Not keep" %></p>
+  <p><%= @habit.completed? ? "Completed today" : "Not Completed" %></p>
 
   <%= link_to "Back to goal", category_goal_path(@category, @goal), class: "btn btn-secondary" %>
   <%= link_to "Edit", edit_goal_habit_path(@goal, @habit), class: "btn btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,10 +31,7 @@ Rails.application.routes.draw do
 
   get "home", to: "pages#home"
   get "about", to: "pages#about"
-  # delete "logout", to: "sessions#destroy"
 
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Defines the root path route ("/")
   root "categories#index"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,6 +23,6 @@ env :PATH, ENV['PATH']
 
 set :output, './log/cron.log'
 
-every 1.minutes do
+every 1.day do
   rake "habit_complete_updater:habit_updater"
 end

--- a/db/migrate/20230613124815_change_column_name_for_habits.rb
+++ b/db/migrate/20230613124815_change_column_name_for_habits.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameForHabits < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :habits, :keep, :completed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_10_123746) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_124815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,7 +54,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_10_123746) do
     t.bigint "goal_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "keep", default: false
+    t.boolean "completed", default: false
     t.index ["goal_id"], name: "index_habits_on_goal_id"
     t.index ["user_id"], name: "index_habits_on_user_id"
   end

--- a/lib/tasks/habit_complete_updater.rake
+++ b/lib/tasks/habit_complete_updater.rake
@@ -4,10 +4,10 @@ namespace :habit_complete_updater do
     completed_habits ||= Habit.where(keep: true)
 
     completed_habits.each do |habit|
-      if habit.updated_at.localtime.strftime('%d %m %Y') < (Time.now.localtime.strftime('%d %m %Y'))
+      if habit.updated_at.localtime.strftime('%d %m %Y') < (Time.now.localtime.strftime('%d %m %Y')) &&
+        habit.completed_today?
         habit.update_attribute(:keep, false)
       end
     end
   end
-
 end


### PR DESCRIPTION
It is important for me to have the `keep` attribute on the `Habit` model instances in order to use its `boolean` value to display completed/failed habits in `views`. With each new day, `rake` task in `lib/tasks/habit_complete_updater.rake` path will reset the `keep` attribute using the `whenever` gem, based on the logic in the `task`.